### PR TITLE
Link the title to the issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# openlibrary-librarians
+# [openlibrary-librarians](../../issues)
 Coordination between the OpenLibrary.org Librarian community
 
 The purpose of this repository is to track and manage Open Library issues that require human review, cleanup, or discussion. This may include bulk edits via [librarian bots](http://github.com/internetarchive/openlibrary-client) but should not include issues with the [Open Library website](https://github.com/internetarchive/openlibrary). 


### PR DESCRIPTION
This PR proposes so make the README.md title a hotlink to the issues because the most important thing to do when visiting this repo is to look at the issues.  Most visitors will never even notice.  Frequent users can just get to work faster.